### PR TITLE
Use arrow linkage as arrow was built rather than trying to rederive it.

### DIFF
--- a/ports/rerun-sdk/arrow-use-built-linkage.diff
+++ b/ports/rerun-sdk/arrow-use-built-linkage.diff
@@ -1,0 +1,33 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 101ee6b8cb..591e47332b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -109,16 +109,24 @@ target_link_libraries(rerun_sdk PRIVATE rerun_c)
+ # Arrow dependency.
+ # This makes the setup a lot easier on Windows where we otherwise need to put Arrow.dll either in path or copy it with the executable.
+ # Additionally reduces risk of picking up system libraries on Mac / Linux.
+-set(RERUN_ARROW_LINK_SHARED_DEFAULT OFF)
+-option(RERUN_ARROW_LINK_SHARED "Link to the Arrow shared library." ${RERUN_ARROW_LINK_SHARED_DEFAULT})
+ option(RERUN_DOWNLOAD_AND_BUILD_ARROW "If enabled, arrow will be added as an external project and built with the minimal set required by the Rerun C++ SDK" ON)
+ 
++if (NOT RERUN_DOWNLOAD_AND_BUILD_ARROW)
++    find_package(Arrow REQUIRED)
++endif()
++
++if (ARROW_BUILD_SHARED)
++    set(RERUN_ARROW_LINK_SHARED_DEFAULT ON)
++else()
++    set(RERUN_ARROW_LINK_SHARED_DEFAULT OFF)
++endif()
++
++option(RERUN_ARROW_LINK_SHARED "Link to the Arrow shared library." ${RERUN_ARROW_LINK_SHARED_DEFAULT})
++
+ if(RERUN_DOWNLOAD_AND_BUILD_ARROW)
+     include(download_and_build_arrow.cmake)
+     download_and_build_arrow() # populates `rerun_arrow_target`
+ else()
+-    find_package(Arrow REQUIRED)
+-
+     if(RERUN_ARROW_LINK_SHARED)
+         add_library(rerun_arrow_target ALIAS Arrow::arrow_shared)
+     else()

--- a/ports/rerun-sdk/arrow-use-find-dependency.diff
+++ b/ports/rerun-sdk/arrow-use-find-dependency.diff
@@ -1,0 +1,15 @@
+diff --git a/Config.cmake.in b/Config.cmake.in
+index c093c4432b..d74bbdfce9 100644
+--- a/Config.cmake.in
++++ b/Config.cmake.in
+@@ -47,7 +47,9 @@ else()
+         )
+     endif()
+ 
+-    find_package(Arrow REQUIRED)
++    include(CMakeFindDependencyMacro)
++
++    find_dependency(Arrow)
+ 
+     message(STATUS "Rerun is using a system installed libArrow.")
+ 

--- a/ports/rerun-sdk/portfile.cmake
+++ b/ports/rerun-sdk/portfile.cmake
@@ -9,15 +9,15 @@ vcpkg_download_distfile(
 vcpkg_extract_source_archive(
     SOURCE_PATH
     ARCHIVE "${ARCHIVE}"
+    PATCHES
+        arrow-use-built-linkage.diff # https://github.com/rerun-io/rerun/pull/9550
+        arrow-use-find-dependency.diff # https://github.com/rerun-io/rerun/pull/9548
 )
-
-string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" ARROW_LINK_SHARED)
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DRERUN_DOWNLOAD_AND_BUILD_ARROW=OFF # Disable downloading and building Arrow
-        -DRERUN_ARROW_LINK_SHARED=${ARROW_LINK_SHARED} # Enable shared linking if not static
 )
 
 vcpkg_cmake_install()
@@ -31,13 +31,14 @@ file(GLOB LIBRERUN_C_FILE
 
 vcpkg_replace_string(
     "${CURRENT_PACKAGES_DIR}/share/rerun_sdk/rerun_sdkConfig.cmake"
-    "${SOURCE_PATH}/lib/${LIBRERUN_C_FILE}"
-    "\${CURRENT_PACKAGES_DIR}/lib/${LIBRERUN_C_FILE}"
-)
-vcpkg_replace_string(
-    "${CURRENT_PACKAGES_DIR}/share/rerun_sdk/rerun_sdkConfig.cmake"
     "set(RERUN_LIB_DIR \"\${CMAKE_CURRENT_LIST_DIR}/../..\")"
     "set(RERUN_LIB_DIR \"\${CMAKE_CURRENT_LIST_DIR}/../../lib\")"
+)
+
+vcpkg_replace_string(
+    "${CURRENT_PACKAGES_DIR}/share/rerun_sdk/rerun_sdkConfig.cmake"
+    "${SOURCE_PATH}/lib/${LIBRERUN_C_FILE}"
+    "\${CMAKE_CURRENT_LIST_DIR}/../../lib/${LIBRERUN_C_FILE}"
 )
 
 vcpkg_install_copyright(FILE_LIST

--- a/versions/r-/rerun-sdk.json
+++ b/versions/r-/rerun-sdk.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "196c22de42ca35219b3ac61769c2cad91b9d2aa1",
+      "git-tree": "255644b917b0f72edaa87b2044b4f39773eac335",
       "version": "0.22.1",
       "port-version": 0
     }


### PR DESCRIPTION
Incorporates https://github.com/rerun-io/rerun/pull/9548 and https://github.com/rerun-io/rerun/pull/9550

After these changes I tested that it built OK with https://github.com/rerun-io/rerun/blob/main/examples/cpp/minimal/main.cpp :

```
C:\Dev\test>dir
 Volume in drive C is OS
 Volume Serial Number is 9288-8F79

 Directory of C:\Dev\test

04/08/2025  10:42 AM    <DIR>          .
04/08/2025  10:40 AM    <DIR>          ..
04/08/2025  10:38 AM               180 CMakeLists.txt
04/08/2025  10:37 AM               756 main.cpp
               2 File(s)            936 bytes
               2 Dir(s)  4,813,367,603,200 bytes free

C:\Dev\test>type CMakeLists.txt
cmake_minimum_required(VERSION 3.10)
project(HelloWorld)

add_executable(main main.cpp)

find_package(rerun_sdk CONFIG REQUIRED)
target_link_libraries(main PRIVATE rerun_sdk)

C:\Dev\test>type main.cpp
#include <rerun.hpp>
#include <rerun/demo_utils.hpp>

using rerun::demo::grid3d;

int main() {
    // Create a new `RecordingStream` which sends data over gRPC to the viewer process.
    const auto rec = rerun::RecordingStream("rerun_example_cpp");
    // Try to spawn a new viewer instance.
    rec.spawn().exit_on_failure();

    // Create some data using the `grid` utility function.
    std::vector<rerun::Position3D> points = grid3d<rerun::Position3D, float>(-10.f, 10.f, 10);
    std::vector<rerun::Color> colors = grid3d<rerun::Color, uint8_t>(0, 255, 10);

    // Log the "my_points" entity with our data, using the `Points3D` archetype.
    rec.log("my_points", rerun::Points3D(points).with_colors(colors).with_radii({0.5f}));
}
C:\Dev\test>cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=C:/Dev/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows  -S . -B build
-- The C compiler identification is MSVC 19.43.34809.0
-- The CXX compiler identification is MSVC 19.43.34809.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.43.34808/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.43.34808/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Arrow version: 19.0.1
-- Found the Arrow shared library: C:/Dev/vcpkg/installed/x64-windows/bin/arrow.dll
-- Found the Arrow import library: C:/Dev/vcpkg/installed/x64-windows/lib/arrow.lib
-- Found the Arrow static library:
-- Rerun is using a system installed libArrow.
-- Configuring done (1.1s)
-- Generating done (0.0s)
-- Build files have been written to: C:/Dev/test/build

C:\Dev\test>ninja -C build
ninja: Entering directory `build'
[2/2] Linking CXX executable main.exe

C:\Dev\test>.\build\main.exe
[2025-04-08T17:48:46Z WARN  rerun_c::error] Error message was too long for C error description buffer. Full message
    Failed to find Rerun Viewer executable in PATH.

        You can install an appropriate version of the Rerun Viewer via binary releases:
        * Using `cargo`: `cargo binstall --force rerun-cli@0.22.1` (see https://github.com/cargo-bins/cargo-binstall)
        * Via direct download from our release assets: https://github.com/rerun-io/rerun/releases/0.22.1/
        * Using `pip`: `pip3 install rerun-sdk==0.22.1`

        For more information, refer to our complete install documentation over at:
        https://rerun.io/docs/getting-started/installing-viewer

    PATH="C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.43.34808\\bin\\HostX64\\x64;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\IDE\\VC\\VCPackages;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\TestWindow;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\TeamFoundation\\Team Explorer;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\MSBuild\\Current\\bin\\Roslyn;C:\\Program Files (x86)\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.8 Tools\\x64\\;C:\\Program Files (x86)\\HTML Help Workshop;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\FSharp\\Tools;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Team Tools\\DiagnosticsHub\\Collector;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\IDE\\Extensions\\Microsoft\\CodeCoverage.Console;C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.26100.0\\\\x64;C:\\Program Files (x86)\\Windows Kits\\10\\bin\\\\x64;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\\\MSBuild\\Current\\Bin\\amd64;C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\IDE\\;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\Tools\\;C:\\Program Files\\Python313\\Scripts\\;C:\\Program Files\\Python313\\;C:\\Program Files\\Microsoft SDKs\\Azure\\CLI2\\wbin;C:\\Program Files\\Microsoft MPI\\Bin\\;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files (x86)\\NVIDIA Corporation\\PhysX\\Common;C:\\Program Files\\dotnet\\;C:\\Program Files\\Microsoft SQL Server\\130\\Tools\\Binn\\;C:\\Program Files\\Microsoft SQL Server\\Client SDK\\ODBC\\170\\Tools\\Binn\\;C:\\Program Files\\Microsoft SQL Server\\150\\Tools\\Binn\\;C:\\Program Files (x86)\\Windows Kits\\10\\Windows Performance Toolkit\\;C:\\Program Files\\NVIDIA Corporation\\NVIDIA app\\NvDLISR;C:\\Program Files\\LLVM\\bin;C:\\WINDOWS\\system32;C:\\WINDOWS;C:\\WINDOWS\\System32\\Wbem;C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\;C:\\WINDOWS\\System32\\OpenSSH\\;C:\\Program Files\\nodejs\\;C:\\Program Files\\PowerShell\\7\\;C:\\Program Files\\CMake\\bin;C:\\Program Files\\GitExtensions\\;C:\\Program Files\\Docker\\Docker\\resources\\bin;C:\\Program Files\\Git\\cmd;C:\\Users\\bion\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\bion\\.dotnet\\tools;C:\\Users\\bion\\AppData\\Local\\Microsoft\\WinGet\\Links;C:\\Users\\bion\\AppData\\Roaming\\npm;;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\Llvm\\x64\\bin;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\CMake\\CMake\\bin;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\CMake\\Ninja;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\IDE\\VC\\Linux\\bin\\ConnectionManagerExe;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\vcpkg"
Rerun ERROR: Failed to find Rerun Viewer executable in PATH.

    You can install an appropriate version of the Rerun Viewer via binary releases:
    * Using `cargo`: `cargo binstall --force rerun-cli@0.22.1` (see https://github.com/cargo-bins/cargo-binstall)
    * Via direct download from our release assets: https://github.com/rerun-io/rerun/releases/0.22.1/
    * Using `pip`: `pip3 install rerun-sdk==0.22.1`

    For more information, refer to our complete install documentation over at:
    https://rerun.io/docs/getting-started/installing-viewer

PATH="C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.43.34808\\bin\\HostX64\\x64;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\IDE\\VC\\VCPackages;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\TestWindow;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\TeamFoundation\\Team Explorer;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\MSBuild\\Current\\bin\\Roslyn;C:\\Program Files (x86)\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.8 Tools\\x64\\;C:\\Program Files (x86)\\HTML Help Workshop;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\FSharp\\Tools;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Team Tools\\DiagnosticsHub\\Collector;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\IDE\\Extensions\\Microsoft\\CodeCoverage.Console;C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.26100.0\\\\x64;C:\\Program Files (x86)\\Windows Kits\\10\\bin\\\\x64;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\\\MSBuild\\Current\\Bin\\amd64;C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\IDE\\;C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\Common7\\Tools\\;C:\\Program Files\\Python313\\Scripts\\;C:\\Program Files\\

C:\Dev\test>
```
